### PR TITLE
Fix CI: switch from MkDocs to Astro

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy MkDocs to GitHub Pages
+name: Deploy Astro to GitHub Pages
 
 on:
   push:
@@ -21,22 +21,27 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
         with:
-          python-version: "3.12"
+          node-version: "22"
 
       - name: Install dependencies
-        run: |
-          pip install mkdocs-material
+        working-directory: astro-site
+        run: npm ci
+
+      - name: Create assets symlink
+        working-directory: astro-site/src/content
+        run: ln -s ../../../assets assets
 
       - name: Build site
-        run: mkdocs build --strict
+        working-directory: astro-site
+        run: npm run build
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: site/
+          path: astro-site/dist/
 
   deploy:
     needs: build


### PR DESCRIPTION
## Summary

- Replace MkDocs/Python build with Astro/Node.js build
- Create assets symlink in CI for image resolution
- Point artifact upload to `astro-site/dist/`

## Test plan

- [ ] Verify GitHub Actions build succeeds
- [ ] Verify site deploys to GitHub Pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)