### PR TITLE
Fix: add base path for GitHub Pages

### DIFF
--- a/astro-site/astro.config.mjs
+++ b/astro-site/astro.config.mjs
@@ -3,6 +3,8 @@ import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({
+  site: 'https://braboj.github.io',
+  base: '/tutorial-git/',
   trailingSlash: 'always',
   markdown: {
     syntaxHighlight: false,

--- a/astro-site/src/components/Header.astro
+++ b/astro-site/src/components/Header.astro
@@ -1,11 +1,12 @@
 ---
 import site from "../data/site.json";
 const { currentPath = "/" } = Astro.props;
+const base = import.meta.env.BASE_URL;
 ---
 
 <div class="site-header-bar">
   <header class="site-header">
-    <a href="/" class="site-header-title">
+    <a href={base} class="site-header-title">
       <svg class="site-header-icon" viewBox="0 0 92 92" width="22" height="22" fill="currentColor" aria-hidden="true">
         <path d="M90.156 41.965 50.036 1.848a5.913 5.913 0 0 0-8.368 0l-8.332 8.332 10.566 10.566a7.03 7.03 0 0 1 7.23 1.684 7.043 7.043 0 0 1 1.673 7.277l10.183 10.184a7.026 7.026 0 0 1 7.278 1.672 7.04 7.04 0 0 1 0 9.957 7.045 7.045 0 0 1-9.961 0 7.038 7.038 0 0 1-1.532-7.66l-9.5-9.497V59.36a7.04 7.04 0 0 1 1.86 11.29 7.04 7.04 0 0 1-9.957 0 7.04 7.04 0 0 1 0-9.958 7.06 7.06 0 0 1 2.304-1.539V35.71a7.04 7.04 0 0 1-3.82-9.234L29.242 16.07 1.73 43.583a5.918 5.918 0 0 0 0 8.37l40.121 40.118a5.916 5.916 0 0 0 8.369 0l39.936-39.934a5.925 5.925 0 0 0 0-8.372"/>
       </svg>
@@ -32,13 +33,13 @@ const { currentPath = "/" } = Astro.props;
 <div class="site-tabs-bar">
   <nav class="site-tabs" aria-label="Main navigation">
     {site.tabs.map((tab) => {
-      // Match by section prefix: /operations/help/ highlights for any /operations/* path
       const tabSection = tab.href.split("/").filter(Boolean)[0];
       const currentSection = currentPath.split("/").filter(Boolean)[0];
       const isActive = tab.href === "/" ? currentPath === "/" : tabSection === currentSection;
+      const href = tab.href === "/" ? base : `${base}${tab.href.slice(1)}`;
       return (
         <a
-          href={tab.href}
+          href={href}
           class:list={[{ active: isActive }]}
           aria-current={isActive ? "page" : undefined}
         >


### PR DESCRIPTION
## Summary

- Add `site` and `base: '/tutorial-git/'` to Astro config
- Prefix header and tab navigation links with base URL

## Test plan

- [ ] Verify CSS and assets load on GitHub Pages
- [ ] Verify all navigation links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)