### PR TITLE
Fix broken cross-references and tutorial links

### DIFF
--- a/astro-site/src/content/docs/appendix.md
+++ b/astro-site/src/content/docs/appendix.md
@@ -8,7 +8,7 @@ order: 8
 
 This appendix contains reference material that supports the tutorial
 chapters — merge strategies, Git clients, external resources, and
-notes. For step-by-step recipes, see the [Playbook](07-playbook.md).
+notes. For step-by-step recipes, see the [Playbook](../playbook/).
 For command help, run `git help <command>`.
 
 ## Merge Strategies

--- a/astro-site/src/content/docs/branching-and-merging.md
+++ b/astro-site/src/content/docs/branching-and-merging.md
@@ -14,7 +14,7 @@ or managing multiple features at once.
 
 ## Branching
 
-As covered in [Building Blocks](02-building-blocks.md), a branch is a
+As covered in [Building Blocks](../building-blocks/), a branch is a
 pointer to a specific commit. Creating a branch is a "cheap" operation —
 Git does not copy any files, it only creates a new reference. This
 section focuses on how branches are used in practice.
@@ -244,7 +244,7 @@ different sources:
 | `git merge` | Both branches changed the same lines |
 | `git rebase` | A replayed commit touches lines modified upstream |
 | `git cherry-pick` | The picked commit overlaps with the current state |
-| `git pull` | Remote changes overlap with local changes (see [Remote Repositories](04-remote-repositories.md)) |
+| `git pull` | Remote changes overlap with local changes (see [Remote Repositories](../remote-repositories/)) |
 | `git stash pop` | Stashed changes conflict with the current working tree |
 
 ### How Git marks conflicts
@@ -445,7 +445,7 @@ A stash is a commit object **W** with two parents:
 ## Exercises
 
 All exercises use the `concepts-lab` repository created in
-[Building Blocks](02-building-blocks.md). If you skipped that chapter, create a new
+[Building Blocks](../building-blocks/). If you skipped that chapter, create a new
 repository with at least one commit before starting.
 
 ### Exercise 1: Branch Lifecycle

--- a/astro-site/src/content/docs/building-blocks.md
+++ b/astro-site/src/content/docs/building-blocks.md
@@ -353,7 +353,7 @@ $ git ls-files --stage
 Each line shows: `<mode> <blob-hash> <stage-flag> <file-path>`. The
 stage flag is `0` during normal operation — it changes to `1`, `2`, or
 `3` only during a merge conflict (covered in
-[Branching and Merging](03-branching-and-merging.md)).
+[Branching and Merging](../branching-and-merging/)).
 
 ### Understanding the Mode Field
 

--- a/astro-site/src/content/docs/glossary.md
+++ b/astro-site/src/content/docs/glossary.md
@@ -8,48 +8,48 @@ order: 9
 
 | Term | Definition | Chapter |
 |------|-----------|---------|
-| Annotated tag | A tag object with author, date, and message — stored in `.git/objects/` | [2](02-building-blocks.md) |
-| Bare repository | A repository with no working tree — only `.git/` internals | [2](02-building-blocks.md) |
-| Bisect | Binary search through commit history to find the commit that introduced a bug | [6](06-expert-topics.md) |
-| Blame | Show which commit and author last modified each line of a file | [7](07-playbook.md) |
-| Blob | Object that stores the raw contents of a single file | [2](02-building-blocks.md) |
-| Branch | A movable pointer to a commit, stored in `.git/refs/heads/` | [2](02-building-blocks.md) |
-| Cherry-pick | Copy a single commit from one branch onto another, creating a new commit with a different hash | [3](03-branching-and-merging.md) |
-| Clone | Create a local copy of a remote repository, including full history, origin remote, and tracking branches | [4](04-remote-repositories.md) |
-| Commit | An object that records a snapshot of the project — references a tree, parent commits, author, and message | [2](02-building-blocks.md) |
-| Conflict | When two branches modify the same lines and Git cannot merge them automatically | [3](03-branching-and-merging.md) |
-| Detached HEAD | State where HEAD points directly to a commit instead of a branch — new commits are orphaned if you switch away | [2](02-building-blocks.md) |
-| Fast-forward | A merge where the target branch simply moves forward to the source branch tip — no merge commit is created | [3](03-branching-and-merging.md) |
-| Fetch | Download commits from a remote and update remote-tracking branches without modifying local branches | [4](04-remote-repositories.md) |
-| Fork | A hosting-platform copy of someone else's repository under your account | [4](04-remote-repositories.md) |
-| Garbage collection | Git's process for removing orphaned objects from `.git/objects/` | [6](06-expert-topics.md) |
-| Hash | A unique 40-character identifier (SHA-1) computed from an object's content | [2](02-building-blocks.md) |
-| HEAD | Reference to the current position — usually points to a branch, sometimes directly to a commit (detached) | [2](02-building-blocks.md) |
-| Hook | A script in `.git/hooks/` that Git runs automatically before or after events like commit or push | [6](06-expert-topics.md) |
-| Index | The staging area — a sorted list of tracked files prepared for the next commit, stored at `.git/index` | [2](02-building-blocks.md) |
-| Interactive rebase | Editing, reordering, squashing, or dropping commits before sharing them | [6](06-expert-topics.md) |
-| Lightweight tag | A tag that is just a file in `.git/refs/tags/` containing a commit hash — no object, no metadata | [2](02-building-blocks.md) |
-| Merge | Combining changes from two branches into one, optionally creating a merge commit | [3](03-branching-and-merging.md) |
-| Merge commit | A commit with two or more parents, created by a 3-way merge | [3](03-branching-and-merging.md) |
-| Origin | Conventional name for the remote you cloned from | [4](04-remote-repositories.md) |
-| Orphaned commit | A commit no branch or tag points to — eligible for garbage collection after reflog expiry | [6](06-expert-topics.md) |
-| Pathspec | A pattern that matches files or directories in Git commands | [6](06-expert-topics.md) |
-| Pull | Fetch from a remote and merge (or rebase) into the current branch | [4](04-remote-repositories.md) |
-| Pull request | A hosting-platform feature for requesting review and merge of a branch | [4](04-remote-repositories.md) |
-| Push | Upload local commits to a remote branch | [4](04-remote-repositories.md) |
-| Rebase | Replay commits from one branch on top of another, producing a linear history | [3](03-branching-and-merging.md) |
-| Reflog | A local log of every position HEAD and branch tips have been in — used to recover lost commits | [6](06-expert-topics.md) |
-| Refspec | Syntax that maps references between a remote and a local repository (e.g. `+refs/heads/*:refs/remotes/origin/*`) | [6](06-expert-topics.md) |
-| Remote | A named reference to another repository, stored in `.git/config` | [4](04-remote-repositories.md) |
-| Remote-tracking branch | A read-only local reference that mirrors a remote branch (e.g. `origin/main`), updated by fetch and pull | [4](04-remote-repositories.md) |
-| Repository | The `.git/` directory containing all objects, references, and configuration for a project | [2](02-building-blocks.md) |
-| Reset | Move HEAD and optionally the branch tip to a different commit — `--soft`, `--mixed`, or `--hard` | [2](02-building-blocks.md) |
-| Revert | Create a new commit that undoes a previous commit's changes without rewriting history | [7](07-playbook.md) |
-| Squash merge | Combine all commits from a branch into a single change set on the target branch — no merge commit | [3](03-branching-and-merging.md) |
-| Stash | Save uncommitted changes temporarily so you can switch branches with a clean working tree | [3](03-branching-and-merging.md) |
-| Submodule | A reference to a specific commit in another repository — stores URL and hash, not files | [5](05-subprojects.md) |
-| Subtree | A full copy of another repository merged into a subdirectory of the parent project | [5](05-subprojects.md) |
-| Tag | A named reference to a commit — annotated (object with metadata) or lightweight (plain reference) | [2](02-building-blocks.md) |
-| Tree | Object that represents a directory — lists blobs and other trees with names and permissions | [2](02-building-blocks.md) |
-| Upstream | Conventional name for the original repository you forked from | [4](04-remote-repositories.md) |
-| Working tree | The checked-out files on disk that you edit directly — everything outside `.git/` | [2](02-building-blocks.md) |
+| Annotated tag | A tag object with author, date, and message — stored in `.git/objects/` | [2](../building-blocks/) |
+| Bare repository | A repository with no working tree — only `.git/` internals | [2](../building-blocks/) |
+| Bisect | Binary search through commit history to find the commit that introduced a bug | [6](../expert-topics/) |
+| Blame | Show which commit and author last modified each line of a file | [7](../playbook/) |
+| Blob | Object that stores the raw contents of a single file | [2](../building-blocks/) |
+| Branch | A movable pointer to a commit, stored in `.git/refs/heads/` | [2](../building-blocks/) |
+| Cherry-pick | Copy a single commit from one branch onto another, creating a new commit with a different hash | [3](../branching-and-merging/) |
+| Clone | Create a local copy of a remote repository, including full history, origin remote, and tracking branches | [4](../remote-repositories/) |
+| Commit | An object that records a snapshot of the project — references a tree, parent commits, author, and message | [2](../building-blocks/) |
+| Conflict | When two branches modify the same lines and Git cannot merge them automatically | [3](../branching-and-merging/) |
+| Detached HEAD | State where HEAD points directly to a commit instead of a branch — new commits are orphaned if you switch away | [2](../building-blocks/) |
+| Fast-forward | A merge where the target branch simply moves forward to the source branch tip — no merge commit is created | [3](../branching-and-merging/) |
+| Fetch | Download commits from a remote and update remote-tracking branches without modifying local branches | [4](../remote-repositories/) |
+| Fork | A hosting-platform copy of someone else's repository under your account | [4](../remote-repositories/) |
+| Garbage collection | Git's process for removing orphaned objects from `.git/objects/` | [6](../expert-topics/) |
+| Hash | A unique 40-character identifier (SHA-1) computed from an object's content | [2](../building-blocks/) |
+| HEAD | Reference to the current position — usually points to a branch, sometimes directly to a commit (detached) | [2](../building-blocks/) |
+| Hook | A script in `.git/hooks/` that Git runs automatically before or after events like commit or push | [6](../expert-topics/) |
+| Index | The staging area — a sorted list of tracked files prepared for the next commit, stored at `.git/index` | [2](../building-blocks/) |
+| Interactive rebase | Editing, reordering, squashing, or dropping commits before sharing them | [6](../expert-topics/) |
+| Lightweight tag | A tag that is just a file in `.git/refs/tags/` containing a commit hash — no object, no metadata | [2](../building-blocks/) |
+| Merge | Combining changes from two branches into one, optionally creating a merge commit | [3](../branching-and-merging/) |
+| Merge commit | A commit with two or more parents, created by a 3-way merge | [3](../branching-and-merging/) |
+| Origin | Conventional name for the remote you cloned from | [4](../remote-repositories/) |
+| Orphaned commit | A commit no branch or tag points to — eligible for garbage collection after reflog expiry | [6](../expert-topics/) |
+| Pathspec | A pattern that matches files or directories in Git commands | [6](../expert-topics/) |
+| Pull | Fetch from a remote and merge (or rebase) into the current branch | [4](../remote-repositories/) |
+| Pull request | A hosting-platform feature for requesting review and merge of a branch | [4](../remote-repositories/) |
+| Push | Upload local commits to a remote branch | [4](../remote-repositories/) |
+| Rebase | Replay commits from one branch on top of another, producing a linear history | [3](../branching-and-merging/) |
+| Reflog | A local log of every position HEAD and branch tips have been in — used to recover lost commits | [6](../expert-topics/) |
+| Refspec | Syntax that maps references between a remote and a local repository (e.g. `+refs/heads/*:refs/remotes/origin/*`) | [6](../expert-topics/) |
+| Remote | A named reference to another repository, stored in `.git/config` | [4](../remote-repositories/) |
+| Remote-tracking branch | A read-only local reference that mirrors a remote branch (e.g. `origin/main`), updated by fetch and pull | [4](../remote-repositories/) |
+| Repository | The `.git/` directory containing all objects, references, and configuration for a project | [2](../building-blocks/) |
+| Reset | Move HEAD and optionally the branch tip to a different commit — `--soft`, `--mixed`, or `--hard` | [2](../building-blocks/) |
+| Revert | Create a new commit that undoes a previous commit's changes without rewriting history | [7](../playbook/) |
+| Squash merge | Combine all commits from a branch into a single change set on the target branch — no merge commit | [3](../branching-and-merging/) |
+| Stash | Save uncommitted changes temporarily so you can switch branches with a clean working tree | [3](../branching-and-merging/) |
+| Submodule | A reference to a specific commit in another repository — stores URL and hash, not files | [5](../subprojects/) |
+| Subtree | A full copy of another repository merged into a subdirectory of the parent project | [5](../subprojects/) |
+| Tag | A named reference to a commit — annotated (object with metadata) or lightweight (plain reference) | [2](../building-blocks/) |
+| Tree | Object that represents a directory — lists blobs and other trees with names and permissions | [2](../building-blocks/) |
+| Upstream | Conventional name for the original repository you forked from | [4](../remote-repositories/) |
+| Working tree | The checked-out files on disk that you edit directly — everything outside `.git/` | [2](../building-blocks/) |

--- a/astro-site/src/content/docs/playbook.md
+++ b/astro-site/src/content/docs/playbook.md
@@ -10,8 +10,8 @@ This chapter is a quick-reference collection of recipes for common
 Git tasks. Each recipe shows the problem, the commands to solve it,
 and what to watch out for.
 
-For command syntax, see [Appendix](08-appendix.md). For definitions,
-see [Glossary](09-glossary.md).
+For command syntax, see [Appendix](../appendix/). For definitions,
+see [Glossary](../glossary/).
 
 ## Undoing changes
 

--- a/astro-site/src/content/docs/remote-repositories.md
+++ b/astro-site/src/content/docs/remote-repositories.md
@@ -12,7 +12,7 @@ local and remote branches in sync. These are the operations that turn
 Git from a local history tool into a collaboration platform.
 
 The basics of connecting to a remote were introduced in
-[Introduction](01-introduction.md) (Exercise 6). This chapter goes
+[Introduction](../introduction/) (Exercise 6). This chapter goes
 deeper into the mechanics and the workflows you will use daily.
 
 ![Remote flow](../assets/images/git-remote-flow.png)
@@ -75,7 +75,7 @@ origin/feature
 upstream/main
 ```
 
-As covered in [Building Blocks](02-building-blocks.md), these references
+As covered in [Building Blocks](../building-blocks/), these references
 live in `.git/refs/remotes/`. They are updated automatically by `fetch`
 and `pull`, never by your local commits.
 
@@ -119,7 +119,7 @@ Git supports two URL protocols:
 | SSH      | `git@github.com:user/repo.git`     | Requires SSH key setup, no password prompts |
 
 HTTPS is simpler to start with. SSH is covered in the
-[Appendix](08-appendix.md).
+[Appendix](../appendix/).
 
 ## Fetching
 
@@ -176,7 +176,7 @@ $ git config --global pull.rebase true
 
 If the remote changes conflict with your local changes, Git stops and
 asks you to resolve the conflict — the same process described in
-[Branching and Merging](03-branching-and-merging.md#conflicts). After
+[Branching and Merging](../branching-and-merging/#conflicts). After
 resolving:
 
 ```text

--- a/astro-site/src/content/docs/subprojects.md
+++ b/astro-site/src/content/docs/subprojects.md
@@ -199,7 +199,7 @@ repository's files.
 initialization.
 
 **Prerequisite:** `concepts-lab` must be pushed to GitHub (see
-[Remote Repositories](04-remote-repositories.md), Exercise 1).
+[Remote Repositories](../remote-repositories/), Exercise 1).
 
 **Steps:**
 

--- a/astro-site/src/data/site.json
+++ b/astro-site/src/data/site.json
@@ -17,15 +17,6 @@
   ],
   "tutorials": [
     { "label": "Azure", "href": "https://braboj.github.io/tutorial-azure/" },
-    { "label": "Dart", "href": "https://braboj.github.io/tutorial-dart/" },
-    { "label": "Docker", "href": "https://braboj.github.io/tutorial-docker/" },
-    { "label": "Exams", "href": "https://braboj.github.io/tutorial-exams/" },
-    { "label": "Microprocessor", "href": "https://braboj.github.io/tutorial-microprocessor/" },
-    { "label": "Modbus", "href": "https://braboj.github.io/tutorial-modbus/" },
-    { "label": "Networks", "href": "https://braboj.github.io/tutorial-networks/" },
-    { "label": "OpenSSL", "href": "https://braboj.github.io/tutorial-openssl/" },
-    { "label": "Operating Systems", "href": "https://braboj.github.io/tutorial-os/" },
-    { "label": "Python", "href": "https://braboj.github.io/tutorial-python/" },
-    { "label": "Testing", "href": "https://braboj.github.io/tutorial-testing/" }
+    { "label": "Python", "href": "https://braboj.github.io/tutorial-python/" }
   ]
 }


### PR DESCRIPTION
## Summary

- Convert all chapter file links (e.g. `03-branching-and-merging.md`) to relative site URLs (e.g. `../branching-and-merging/`)
- Remove 9 dead tutorial sidebar links — only Azure and Python are deployed

Closes #88, closes #89, closes #90, closes #91, closes #92

## Test plan

- [ ] Verify cross-references navigate correctly between chapters
- [ ] Verify tutorial sidebar shows only live links

🤖 Generated with [Claude Code](https://claude.com/claude-code)