### PR TITLE
fix: set canonical domain to braboj.me

### DIFF
--- a/astro-site/astro.config.mjs
+++ b/astro-site/astro.config.mjs
@@ -5,7 +5,7 @@ import { remarkRewriteLinks } from './src/plugins/remark-rewrite-links.ts';
 
 // https://astro.build/config
 export default defineConfig({
-  site: 'https://braboj.github.io',
+  site: 'https://braboj.me',
   base: '/tutorial-git/',
   trailingSlash: 'always',
   integrations: [sitemap()],


### PR DESCRIPTION
## Summary
- Update `site` in astro.config.mjs from `braboj.github.io` to `braboj.me`
- Ensures sitemap, canonical URLs, and OG tags point to the custom domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)