### PR TITLE
fix: update robots.txt sitemap URL to braboj.me

### DIFF
--- a/astro-site/public/robots.txt
+++ b/astro-site/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://braboj.github.io/tutorial-git/sitemap-index.xml
+Sitemap: https://braboj.me/tutorial-git/sitemap-index.xml


### PR DESCRIPTION
## Summary
- Fix sitemap URL in robots.txt to match canonical domain (braboj.me instead of braboj.github.io)
- Google Search Console was rejecting the sitemap because of the domain mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)