### PR TITLE
fix: exclude symlink from lychee to prevent CI hang

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -7,6 +7,9 @@ exclude = [
   "^http://",
 ]
 
+# Skip the symlink directory to prevent recursive scanning
+exclude_path = ["astro-site/dist/tutorial-git"]
+
 # Accept 200 and 204
 accept = [200, 204]
 


### PR DESCRIPTION
## Summary
- Add `exclude_path` to `lychee.toml` to skip the `dist/tutorial-git` symlink
- The symlink points back to `dist/`, causing lychee to scan all HTML files recursively and hang

🤖 Generated with [Claude Code](https://claude.com/claude-code)