### PR TITLE
fix: remove symlink before artifact upload to prevent infinite loop

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,6 +48,9 @@ jobs:
           args: --root-dir astro-site/dist --config lychee.toml 'astro-site/dist/**/*.html'
           fail: true
 
+      - name: Remove symlink before upload
+        run: rm astro-site/dist/tutorial-git
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Summary
- Remove the `dist/tutorial-git` symlink after lychee runs but before `upload-pages-artifact`
- The symlink points back to `dist/`, causing the upload action to recurse infinitely and hang

🤖 Generated with [Claude Code](https://claude.com/claude-code)