### PR TITLE
Fix unclear wording in intro chapter

### DIFF
--- a/chapters/01-introduction.md
+++ b/chapters/01-introduction.md
@@ -115,9 +115,7 @@ The repository stores the full history of your project as a series of
 snapshots called *commits*. Each commit records exactly what the project
 looked like at that moment. The repository can be **local** (on your
 machine) or **remote** (on a hosting service like GitHub). Git treats
-both as equals — there is no single authoritative copy. (The word "master"
-here means primary, not the branch name `master` — Git uses `main` as the
-default branch name.)
+both as equals — there is no single authoritative copy.
 
 ### How a Commit Works
 


### PR DESCRIPTION
## Summary

Removes the confusing parenthetical disclaimer about "master" vs "main" from the Repository section. The sentence says "no single authoritative copy" — the word "master" doesn't appear, so the disclaimer was misleading readers into thinking it did.

Closes #164

## Test plan

- [ ] Read the Repository section — flows naturally without the parenthetical

Generated with [Claude Code](https://claude.com/claude-code)