### PR TITLE
Make end-of-session checklist explicit in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,13 +65,15 @@ Extends `base/scope.md` with tutorial-specific boundaries:
 
 Before ending a session, verify all of the following:
 
-1. **Dev journal** — update `docs/dev-journal.md` with a session entry
-   (date, tool, key changes, decisions, open issues)
-2. **ONBOARDING.md** — update `docs/ONBOARDING.md` if prerequisites,
+1. **Dev journal** — add a session entry to `docs/dev-journal.md`
+   (date, tool, key changes, PRs merged, issues closed/created, open issues)
+2. **CLAUDE.md** — update if project structure or conventions changed
+3. **README.md** — update if chapter list, links, or setup instructions changed
+4. **ONBOARDING.md** — update `docs/ONBOARDING.md` if prerequisites,
    setup steps, or project structure changed
-3. **PLAYBOOK.md** — update `docs/PLAYBOOK.md` if operational
-   workflows changed (diagram export, chapter review process, etc.)
-4. **solid-ai-templates** — check if upstream submodule needs updates
+5. **PLAYBOOK.md** — update `docs/PLAYBOOK.md` if operational
+   workflows or file paths changed
+6. **solid-ai-templates** — check if upstream submodule needs updates
    based on new patterns or conventions discovered during the session
    (e.g. new scope rules, documentation rules, quality conventions)
 5. **Open issues** — close resolved GitHub issues, update or create


### PR DESCRIPTION
## Summary

Expands the end-of-session checklist to include CLAUDE.md and README.md, and clarifies the trigger conditions for each doc update.

## Test plan

- [ ] Checklist items are clear and actionable

Generated with [Claude Code](https://claude.com/claude-code)