### PR TITLE
Fix issue template labels to match label names

### DIFF
--- a/.github/ISSUE_TEMPLATE/spike.md
+++ b/.github/ISSUE_TEMPLATE/spike.md
@@ -2,7 +2,7 @@
 name: Spike
 about: Research or exploration — output is a decision or ADR
 title: ""
-labels: question
+labels: spike
 assignees: ""
 ---
 

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -2,7 +2,7 @@
 name: Task
 about: Atomic implementable unit of work
 title: ""
-labels: enhancement
+labels: task
 assignees: ""
 ---
 


### PR DESCRIPTION
## Summary

- spike.md: `question` → `spike`
- task.md: `enhancement` → `task`

Labels were created but templates still referenced old GitHub default labels.

## Test plan

- [ ] Creating a spike issue auto-assigns the `spike` label
- [ ] Creating a task issue auto-assigns the `task` label

Generated with [Claude Code](https://claude.com/claude-code)