### PR TITLE
docs: inherit end-of-session checks from base/scope.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -284,9 +284,10 @@ Before ending a session, verify all of the following:
    setup steps, or project structure changed
 5. **PLAYBOOK.md** — update `docs/PLAYBOOK.md` if operational
    workflows or file paths changed
-6. **solid-ai-templates** — check if upstream submodule needs updates
-7. **Open issues** — close resolved GitHub issues, update or create
+6. **Open issues** — close resolved GitHub issues, update or create
    issues for remaining work
+7. Remaining checks (submodules, template feedback, flag gaps) are
+   inherited from `base/scope.md` — follow them
 
 
 ## 4. Commands


### PR DESCRIPTION
## Summary

- Remove redundant "solid-ai-templates" submodule check (now in base/scope.md item 8)
- Add explicit reference to inherited checks (submodules, template feedback, flag gaps)

Depends on: Imbra-Ltd/solid-ai-templates#60

## Test plan

- [ ] Verify end-of-session checklist is complete when combining local items + inherited items

🤖 Generated with [Claude Code](https://claude.com/claude-code)