### PR TITLE
fix: broken recipe-to-recipe cross-reference links

### DIFF
--- a/chapters/recipes/commit-msg-hook.md
+++ b/chapters/recipes/commit-msg-hook.md
@@ -51,5 +51,5 @@ $ chmod +x .git/hooks/commit-msg
 
 ### Sharing and bypassing
 
-Same as other hooks — see the [Hooks](hooks.md) recipe for
+Same as other hooks — see the [Hooks](../hooks/) recipe for
 `core.hooksPath` and `--no-verify`.

--- a/chapters/recipes/debugging.md
+++ b/chapters/recipes/debugging.md
@@ -9,7 +9,7 @@ order: 80
 
 ### Find which commit introduced a bug
 
-Use [Git Bisect](git-bisect.md) for a full walkthrough of manual and
+Use [Git Bisect](../git-bisect/) for a full walkthrough of manual and
 automated binary search through commit history.
 
 ### See who last changed each line

--- a/chapters/recipes/git-bisect.md
+++ b/chapters/recipes/git-bisect.md
@@ -54,4 +54,4 @@ commit when done.
 - Use `git bisect log` to replay or share a bisect session.
 
 For blame, log search, and other debugging tools, see the
-[Debugging](debugging.md) recipe.
+[Debugging](../debugging/) recipe.

--- a/chapters/recipes/hooks.md
+++ b/chapters/recipes/hooks.md
@@ -9,12 +9,12 @@ order: 83
 
 ### Create a pre-commit hook
 
-See [Pre-commit Hook](pre-commit-hook.md) for a full walkthrough —
+See [Pre-commit Hook](../pre-commit-hook/) for a full walkthrough —
 script creation, common checks, and sharing with the team.
 
 ### Create a commit-msg hook
 
-See [Commit-msg Hook](commit-msg-hook.md) for a full walkthrough —
+See [Commit-msg Hook](../commit-msg-hook/) for a full walkthrough —
 message validation, Conventional Commits enforcement, and examples.
 
 ### Share hooks with the team

--- a/chapters/recipes/pre-commit-hook.md
+++ b/chapters/recipes/pre-commit-hook.md
@@ -46,7 +46,7 @@ $ chmod +x .git/hooks/pre-commit
 ### Sharing pre-commit hooks
 
 Hooks in `.git/hooks/` are local and not committed. To share them
-with the team, see the [Hooks](hooks.md) recipe for the
+with the team, see the [Hooks](../hooks/) recipe for the
 `core.hooksPath` approach.
 
 ### Bypassing

--- a/chapters/recipes/remote-management.md
+++ b/chapters/recipes/remote-management.md
@@ -46,6 +46,6 @@ $ git remote set-url origin git@github.com:<user>/<repo>.git
 
 ### Set up SSH authentication
 
-See [SSH Setup](ssh-setup.md) for a full walkthrough — key
+See [SSH Setup](../ssh-setup/) for a full walkthrough — key
 generation, agent configuration, GitHub registration, and
 troubleshooting.

--- a/chapters/recipes/remove-submodule.md
+++ b/chapters/recipes/remove-submodule.md
@@ -41,5 +41,5 @@ $ git commit -m "Remove submodule"
 - **Nested submodules** — if the submodule itself contains submodules,
   you need to deinit recursively or clean up `.git/modules/` manually.
 
-For other submodule operations, see the [Submodules](submodules.md)
+For other submodule operations, see the [Submodules](../submodules/)
 recipe.

--- a/chapters/recipes/submodules.md
+++ b/chapters/recipes/submodules.md
@@ -43,6 +43,6 @@ $ git commit -m "Update submodule"
 
 ### Remove a submodule
 
-See [Remove a Submodule](remove-submodule.md) for a full
+See [Remove a Submodule](../remove-submodule/) for a full
 walkthrough — the three cleanup steps, what each does, and common
 gotchas.


### PR DESCRIPTION
## Summary

- Fix 9 broken cross-reference links between recipe pages
- The remark sibling rewriter turns `slug.md` → `slug/`, which resolves to `/playbook/current/slug/` instead of `/playbook/slug/`
- Use `../slug/` directly so the rewriter leaves the link untouched and the browser resolves it correctly

## Test plan

- [x] Astro build passes
- [ ] Verify all 9 cross-reference links work in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)