### PR TITLE
docs: add worktree to glossary

### DIFF
--- a/chapters/09-glossary.md
+++ b/chapters/09-glossary.md
@@ -55,4 +55,5 @@ A reference of key Git terms used throughout this tutorial, with links to the ch
 | Tag | A named reference to a commit — annotated (object with metadata) or lightweight (plain reference) | [2](02-building-blocks.md) |
 | Tree | Object that represents a directory — lists blobs and other trees with names and permissions | [2](02-building-blocks.md) |
 | Upstream | Conventional name for the original repository you forked from | [4](04-remote-repositories.md) |
-| Working tree | The checked-out files on disk that you edit directly — everything outside `.git/` | [2](02-building-blocks.md) |
+| Working tree | The checked-out files on disk that you edit directly — everything outside `.git/`. Also called *worktree* or *workspace* | [1](01-introduction.md), [2](02-building-blocks.md) |
+| Worktree | See *Working tree* | |


### PR DESCRIPTION
## Summary

- Add worktree/workspace as synonyms to the Working tree glossary entry
- Add cross-reference entry for Worktree
- Link to Chapter 1 where the term is first introduced

Closes #158

## Test plan

- [x] `npm run build` passes

Generated with [Claude Code](https://claude.com/claude-code)