### PR TITLE
fix: close mobile nav when tapping outside the menu

### DIFF
--- a/astro-site/src/components/Header.astro
+++ b/astro-site/src/components/Header.astro
@@ -77,9 +77,17 @@ const base = import.meta.env.BASE_URL;
   const navToggle = document.getElementById("nav-toggle");
   const siteTabs = document.getElementById("site-tabs");
 
-  navToggle.addEventListener("click", () => {
+  navToggle.addEventListener("click", (e) => {
+    e.stopPropagation();
     const expanded = navToggle.getAttribute("aria-expanded") === "true";
     navToggle.setAttribute("aria-expanded", String(!expanded));
     siteTabs.classList.toggle("open");
+  });
+
+  document.addEventListener("click", (e) => {
+    if (!siteTabs.classList.contains("open")) return;
+    if (navToggle.contains(e.target) || siteTabs.contains(e.target)) return;
+    navToggle.setAttribute("aria-expanded", "false");
+    siteTabs.classList.remove("open");
   });
 </script>


### PR DESCRIPTION
## Summary

- Add document-level click listener that closes the mobile navigation when tapping outside the hamburger button and nav panel
- Fixes #171

## Test plan

- [ ] Open site on mobile (or responsive mode at ≤768px)
- [ ] Tap hamburger to open nav
- [ ] Tap outside the nav panel — nav should close
- [ ] Tap hamburger to open, then tap a nav link — navigation should work normally
- [ ] On desktop (>768px) verify no change in behavior