### PR TITLE
fix: make code blocks respond to dark mode theme toggle

### DIFF
--- a/astro-site/src/styles/global.css
+++ b/astro-site/src/styles/global.css
@@ -19,6 +19,8 @@
   --color-border: #0000001f;
   --color-link: #00796b;
   --color-focus: #00796b;
+  --color-code-bg: #f5f5f5;
+  --color-code-fg: #212121;
 
   /* Spacing */
   --space-xs: 0.25rem;
@@ -55,6 +57,8 @@
   --color-border: #ffffff1f;
   --color-link: #4dd0e1;
   --color-focus: #4dd0e1;
+  --color-code-bg: #2a2a2a;
+  --color-code-fg: #e0e0e0;
 }
 
 /* Reset */
@@ -531,8 +535,8 @@ a:hover {
 }
 
 .content pre {
-  background: #1e1e1e;
-  color: #e0e0e0;
+  background: var(--color-code-bg);
+  color: var(--color-code-fg);
   border-radius: 4px;
   padding: var(--space-md);
   margin-bottom: var(--space-lg);


### PR DESCRIPTION
## Summary

- Add `--color-code-bg` and `--color-code-fg` CSS variables to both light and dark themes
- Replace hardcoded `#1e1e1e` / `#e0e0e0` in `.content pre` with the new variables
- Light mode: `#f5f5f5` bg / `#212121` text — distinct from white page background
- Dark mode: `#2a2a2a` bg / `#e0e0e0` text — distinct from `#1e1e1e` page background
- Closes #159

## Test plan

- [ ] Toggle between light and dark mode — code blocks should visually adapt
- [ ] Code blocks have clear contrast against the page background in both themes
- [ ] CI passes