### PR TITLE
fix: prevent horizontal scroll hiding mobile ToC button

### DIFF
--- a/astro-site/src/styles/global.css
+++ b/astro-site/src/styles/global.css
@@ -74,6 +74,7 @@ html {
   font-size: 16px;
   scroll-behavior: smooth;
   scroll-padding-top: calc(var(--header-height) + var(--tab-height) + var(--space-md));
+  overflow-x: hidden;
 }
 
 body {


### PR DESCRIPTION
## Summary

- Add `overflow-x: hidden` on `html` to prevent wide content from creating horizontal scroll
- Fixes the mobile ToC FAB appearing off-screen on pages with wide tables or code blocks

## Test plan

- [ ] CI passes
- [ ] On mobile: FAB visible on all pages (introduction, remote repos, expert topics, glossary)
- [ ] No horizontal scroll on any page
- [ ] Wide code blocks and tables still readable (scroll within their container)