### PR TITLE
feat: add print styles for chapters

### DIFF
--- a/astro-site/src/styles/global.css
+++ b/astro-site/src/styles/global.css
@@ -672,3 +672,43 @@ a:hover {
     padding: var(--space-lg) var(--space-md);
   }
 }
+
+@media print {
+  .site-header-bar,
+  .site-tabs-bar,
+  .sidebar-toc,
+  .sidebar-tutorials,
+  .resize-handle,
+  .mobile-toc,
+  .site-footer,
+  .skip-link {
+    display: none !important;
+  }
+
+  .site-main {
+    display: block;
+  }
+
+  .content {
+    padding: 0;
+    max-width: 100%;
+  }
+
+  a {
+    color: inherit;
+    text-decoration: underline;
+  }
+
+  pre {
+    white-space: pre-wrap;
+    border: 1px solid #ccc;
+  }
+
+  img {
+    break-inside: avoid;
+  }
+
+  h2, h3, h4 {
+    break-after: avoid;
+  }
+}


### PR DESCRIPTION
## Summary

- Add `@media print` rules to hide nav, sidebars, FAB, footer, and skip link
- Prevent page breaks after headings and inside images
- Wrap long code blocks instead of clipping
- Closes #214

## Test plan

- [ ] CI passes
- [ ] Print preview (Ctrl+P) shows only chapter content
- [ ] No navigation or UI chrome visible in print
- [ ] Code blocks wrap instead of overflowing