### PR TITLE
chore: release v2.1.0

### DIFF
--- a/astro-site/package.json
+++ b/astro-site/package.json
@@ -1,7 +1,7 @@
 {
   "name": "astro-site",
   "type": "module",
-  "version": "1.0.0",
+  "version": "2.1.0",
   "engines": {
     "node": ">=22.12.0"
   },


### PR DESCRIPTION
## Summary

- Bump `astro-site/package.json` version from `1.0.0` to `2.1.0`
- First GitHub release since v2.0.0 (Astro migration)
- 85 commits: single-source content model, playbook with 25 recipes, dark mode, OG tags, mobile ToC, print styles, all P0/P1 issues resolved

## Test plan

- [ ] Verify `package.json` version is `2.1.0`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)