### PR TITLE
feat: add teal Git branching favicon

### DIFF
--- a/astro-site/public/favicon.svg
+++ b/astro-site/public/favicon.svg
@@ -1,9 +1,13 @@
-<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 128 128">
-    <path d="M50.4 78.5a75.1 75.1 0 0 0-28.5 6.9l24.2-65.7c.7-2 1.9-3.2 3.4-3.2h29c1.5 0 2.7 1.2 3.4 3.2l24.2 65.7s-11.6-7-28.5-7L67 45.5c-.4-1.7-1.6-2.8-2.9-2.8-1.3 0-2.5 1.1-2.9 2.7L50.4 78.5Zm-1.1 28.2Zm-4.2-20.2c-2 6.6-.6 15.8 4.2 20.2a17.5 17.5 0 0 1 .2-.7 5.5 5.5 0 0 1 5.7-4.5c2.8.1 4.3 1.5 4.7 4.7.2 1.1.2 2.3.2 3.5v.4c0 2.7.7 5.2 2.2 7.4a13 13 0 0 0 5.7 4.9v-.3l-.2-.3c-1.8-5.6-.5-9.5 4.4-12.8l1.5-1a73 73 0 0 0 3.2-2.2 16 16 0 0 0 6.8-11.4c.3-2 .1-4-.6-6l-.8.6-1.6 1a37 37 0 0 1-22.4 2.7c-5-.7-9.7-2-13.2-6.2Z" />
-    <style>
-        path { fill: #000; }
-        @media (prefers-color-scheme: dark) {
-            path { fill: #FFF; }
-        }
-    </style>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <!-- Git-inspired branching icon in codewithbranko teal -->
+  <!-- Main branch line (vertical) -->
+  <line x1="64" y1="20" x2="64" y2="108" stroke="#009688" stroke-width="8" stroke-linecap="round"/>
+  <!-- Feature branch line (curves right then back) -->
+  <path d="M64 44 C64 44, 96 44, 96 64 C96 84, 64 84, 64 84" fill="none" stroke="#4db6ac" stroke-width="8" stroke-linecap="round"/>
+  <!-- Commit dots on main -->
+  <circle cx="64" cy="28" r="10" fill="#00796b"/>
+  <circle cx="64" cy="64" r="10" fill="#00796b"/>
+  <circle cx="64" cy="100" r="10" fill="#00796b"/>
+  <!-- Commit dot on feature branch -->
+  <circle cx="96" cy="64" r="10" fill="#4db6ac"/>
 </svg>


### PR DESCRIPTION
## Summary

- Replace default Astro rocket favicon with a Git-inspired branching icon in codewithbranko teal palette
- Main branch (dark teal `#00796b`) with 3 commit dots, feature branch (light teal `#4db6ac`) with 1 commit dot

Closes #151

## Test plan

- [ ] Favicon displays in browser tab
- [ ] Works in Chrome, Firefox, Safari, Edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)