### PR TITLE
docs: add capability list to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@ to confident daily use. It covers everything from installation to
 advanced topics like rebase, bisect, and submodules. The content is
 published as a static site built with Astro and deployed to GitHub Pages.
 
+- Chapters covering installation through expert topics (hooks, bisect, refspecs)
+- Step-by-step recipes for common Git tasks
+- Exercises with verification steps in every chapter
+- Quizzes at the end of each chapter
+- Concepts-first approach — object model and references before commands
+- Glossary of key terms cross-referenced to chapters
+
 ## Quick start
 
 Prerequisites: [Node.js](https://nodejs.org/) 22+


### PR DESCRIPTION
## Summary

- Add the MUST capability list after the summary per `base/readme.md` section 1
- Found during 360-degree analysis (Quality category)

## Test plan

- [ ] Verify the list reads as capabilities, not counts
- [ ] Confirm README still renders correctly on GitHub

Generated with [Claude Code](https://claude.com/claude-code)